### PR TITLE
Fixup ractive edge.

### DIFF
--- a/ractive-decorators-select2.js
+++ b/ractive-decorators-select2.js
@@ -57,7 +57,7 @@
 
     select2Decorator = function (node, type) {
 
-        var ractive = node._ractive.root;
+        var ractive = node._ractive.root || node._ractive.ractive;
         var setting = false;
         var observer;
 
@@ -75,7 +75,9 @@
 
         // Push changes from ractive to select2
         if (node._ractive.binding) {
-            observer = ractive.observe(node._ractive.binding.keypath.str, function (newvalue) {
+            var binding = node._ractive.binding;
+            var keypath = binding.keypath ? binding.keypath.str : binding.model.key;
+            observer = ractive.observe(keypath, function (newvalue) {
                 if (!setting) {
                     setting = true;
                     window.setTimeout(function () {


### PR DESCRIPTION
This gets the plugin working with ractive from edge.  Not sure if you want to wait until 0.8 is released to merge in case they change the internals a bit, but it works for me as of today.

Ractive has done a major refactor for 0.8 which causes this to fail.
The ractive instance and keypath are now in different locations.
